### PR TITLE
Implement login feature with SSO and credentials

### DIFF
--- a/cmd/argocd-tui/main.go
+++ b/cmd/argocd-tui/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Jack200062/ArguTUI/config"
+	"github.com/Jack200062/ArguTUI/internal/auth"
 	"github.com/Jack200062/ArguTUI/internal/transport/argocd"
 	"github.com/Jack200062/ArguTUI/internal/ui"
 	"github.com/Jack200062/ArguTUI/internal/ui/common"
@@ -44,18 +45,37 @@ func main() {
 
 	switchToInstance := func(inst *config.Instance) {
 		instanceInfo := common.NewInstanceInfo(inst.Url, inst.Name)
+		noAuthClient := argocd.NewArgoCdClient(inst, logger, ctx)
 
-		argocdClient := argocd.NewArgoCdClient(inst, logger, ctx)
+		authHandler := auth.NewAuth(instanceInfo.Name, inst, noAuthClient, logger, ctx)
+		authHandler.WithApp(tviewApp)
+		authHandler.WithRouter(router)
+		// using default browser opener
 
-		apps, err := argocdClient.GetApps()
-		if err != nil {
-			logger.Errorf("Error getting all applications: %v", err)
-			return
-		}
+		// get token, fetch apps and render the list
+		go func() {
+			token, err := authHandler.GetToken()
+			if err != nil {
+				logger.Errorf("Error getting auth token: %v", err)
+				// this cannot continue. close the app
+				tviewApp.Stop()
+				return
+			}
+			inst.Token = token
 
-		appList := applicationlist.New(tviewApp, argocdClient, router, instanceInfo, apps)
-		router.AddScreen(appList)
-		router.SwitchTo(appList.Name())
+			tviewApp.QueueUpdateDraw(func() {
+				argocdClient := argocd.NewArgoCdClient(inst, logger, ctx)
+				apps, err := argocdClient.GetApps()
+				if err != nil {
+					logger.Errorf("Error getting all applications: %v", err)
+					return
+				}
+
+				appList := applicationlist.New(tviewApp, argocdClient, router, instanceInfo, apps)
+				router.AddScreen(appList)
+				router.SwitchTo(appList.Name())
+			})
+		}()
 	}
 
 	if len(cfg.Instances) > 1 {
@@ -63,7 +83,11 @@ func main() {
 		router.AddScreen(instanceSelection)
 		router.SwitchTo(instanceSelection.Name())
 	} else if len(cfg.Instances) == 1 {
-		switchToInstance(cfg.Instances[0])
+		inst := cfg.Instances[0]
+		// Create and show a placeholder that will be replaced by login screen
+		placeholder := tview.NewBox().SetBackgroundColor(0x000000)
+		tviewApp.SetRoot(placeholder, true)
+		switchToInstance(inst)
 	} else {
 		logger.Fatal("No instances found in config")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Jack200062/ArguTUI/pkg/logging"
@@ -41,6 +42,12 @@ func parseConfig(v *viper.Viper) (*Config, error) {
 	if err := v.Unmarshal(&c); err != nil {
 		return nil, err
 	}
+	// set defaults
+	for _, inst := range c.Instances {
+		if inst.LoginType == "" {
+			inst.LoginType = LOGIN_TYPE_TOKEN
+		}
+	}
 	return &c, nil
 }
 
@@ -52,8 +59,9 @@ func validateConfig(c *Config) error {
 		if inst.Url == "" {
 			return errors.New("instance url is required")
 		}
-		if inst.Token == "" {
-			return errors.New("instance token is required")
+
+		if inst.LoginType != LOGIN_TYPE_TOKEN && inst.LoginType != LOGIN_TYPE_CREDENTIALS && inst.LoginType != LOGIN_TYPE_SSO {
+			return fmt.Errorf("loginType should be one of (%s, %s, %s)", LOGIN_TYPE_TOKEN, LOGIN_TYPE_CREDENTIALS, LOGIN_TYPE_SSO)
 		}
 	}
 	return nil

--- a/config/models.go
+++ b/config/models.go
@@ -1,11 +1,20 @@
 package config
 
 type Instance struct {
-	Name               string `mapstructure:"name"`
-	Url                string `mapstructure:"url"`
-	Token              string `mapstructure:"token"`
-	InsecureSkipVerify bool   `mapstructure:"insecureskipverify"`
+	Name               string    `mapstructure:"name"`
+	Url                string    `mapstructure:"url"`
+	Token              string    `mapstructure:"token"`
+	LoginType          LoginType `mapstructure:"logintype"`
+	InsecureSkipVerify bool      `mapstructure:"insecureskipverify"`
 }
+
+type LoginType string
+
+const (
+	LOGIN_TYPE_TOKEN       LoginType = "token"
+	LOGIN_TYPE_CREDENTIALS LoginType = "credentials"
+	LOGIN_TYPE_SSO         LoginType = "sso"
+)
 
 type Config struct {
 	Instances []*Instance `mapstructure:"instances"`

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,239 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rivo/tview"
+	"github.com/skratchdot/open-golang/open"
+	keyring "github.com/zalando/go-keyring"
+
+	"github.com/Jack200062/ArguTUI/config"
+	"github.com/Jack200062/ArguTUI/internal/transport/argocd"
+	"github.com/Jack200062/ArguTUI/internal/ui"
+	"github.com/Jack200062/ArguTUI/pkg/logging"
+)
+
+const APP_NAME = "Jack200062.ArgoTUI"
+
+// OAuth2 flow constants
+const ()
+
+type AuthTokens struct {
+	Type         config.LoginType `json:"type"`
+	RefreshToken string           `json:"refresh_token,omitempty"`
+}
+
+type BrowserOpener interface {
+	Open(url string) error
+}
+
+// DefaultBrowserOpener uses the system default browser
+type DefaultBrowserOpener struct{}
+
+func (d *DefaultBrowserOpener) Open(url string) error {
+	return open.Start(url)
+}
+
+type pkceChallenge struct {
+	Verifier  string
+	Challenge string
+}
+
+type oauth2Result struct {
+	Token        string
+	RefreshToken string
+	Error        error
+}
+
+type Auth struct {
+	name          string
+	instanceCfg   *config.Instance
+	client        *argocd.ArgoCdClient
+	logger        *logging.Logger
+	app           *tview.Application
+	router        *ui.Router
+	keyring       any
+	browserOpener BrowserOpener
+}
+
+func NewAuth(name string, instanceCfg *config.Instance, client *argocd.ArgoCdClient, logger *logging.Logger, ctx context.Context) *Auth {
+	return &Auth{
+		name:          name,
+		instanceCfg:   instanceCfg,
+		client:        client,
+		logger:        logger,
+		browserOpener: &DefaultBrowserOpener{},
+	}
+}
+
+// WithBrowserOpener sets a custom browser opener (useful for testing)
+func (a *Auth) WithBrowserOpener(opener BrowserOpener) *Auth {
+	a.browserOpener = opener
+	return a
+}
+
+// WithRouter sets the UI router
+func (a *Auth) WithRouter(router *ui.Router) *Auth {
+	a.router = router
+	return a
+}
+
+// WithApp sets the tview application
+func (a *Auth) WithApp(app *tview.Application) *Auth {
+	a.app = app
+	return a
+}
+
+func (a *Auth) GetToken() (string, error) {
+	ctx := context.Background()
+
+	loginType := a.instanceCfg.LoginType
+	if loginType == config.LOGIN_TYPE_TOKEN {
+		return a.instanceCfg.Token, nil
+	}
+
+	// Try to get refresh token from keychain and use it to get a fresh access token
+	authTokens, err := a.getTokenFromKeychain()
+	if err == nil && authTokens.RefreshToken != "" {
+		a.logger.Debugf("Found refresh token in keychain, getting fresh access token")
+		newToken, newRefreshToken, _, err := a.refreshToken(ctx, authTokens)
+		if err == nil {
+			// Save updated refresh token if it changed
+			if newRefreshToken != "" && newRefreshToken != authTokens.RefreshToken {
+				if err := a.saveTokenToKeychain(authTokens.Type, newRefreshToken); err != nil {
+					a.logger.Debugf("Failed to save updated refresh token: %v", err)
+				}
+			}
+			return newToken, nil
+		}
+		a.logger.Debugf("Failed to refresh token: %v, will perform fresh login", err)
+	} else {
+		a.logger.Debugf("No refresh token found in keychain: %v", err)
+	}
+
+	// No valid refresh token, perform full login
+	a.logger.Debugf("Performing fresh login")
+	var tokenString, refreshToken string
+
+	switch loginType {
+	case config.LOGIN_TYPE_SSO:
+		tokenString, refreshToken, _, err = a.performSSOLogin(ctx)
+	case config.LOGIN_TYPE_CREDENTIALS:
+		tokenString, refreshToken, _, err = a.passwordLogin(ctx)
+	default:
+		err = fmt.Errorf("LoginType=%s is not supported", loginType)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("login failed: %w", err)
+	}
+
+	// Save refresh token to keychain
+	if refreshToken != "" {
+		if err := a.saveTokenToKeychain(loginType, refreshToken); err != nil {
+			a.logger.Debugf("Failed to save refresh token to keychain: %v", err)
+		}
+	}
+
+	return tokenString, nil
+}
+
+func (a *Auth) refreshToken(ctx context.Context, token AuthTokens) (string, string, int64, error) {
+	switch token.Type {
+	case config.LOGIN_TYPE_SSO:
+		return a.refreshOauthToken(ctx, token.RefreshToken)
+	case config.LOGIN_TYPE_CREDENTIALS:
+		return a.refreshPasswordToken(ctx, token.RefreshToken)
+	default:
+		return "", "", 0, fmt.Errorf("Cannot refresh token with LoginType=%s", token.Type)
+	}
+}
+
+// getTokenFromKeychain retrieves the refresh token from the system keychain
+func (a *Auth) getTokenFromKeychain() (AuthTokens, error) {
+	var authTokens AuthTokens
+
+	rawToken, err := keyring.Get(APP_NAME, a.name)
+	if err != nil {
+		return AuthTokens{}, err
+	}
+
+	if err := json.Unmarshal([]byte(rawToken), &authTokens); err != nil {
+		return AuthTokens{}, fmt.Errorf("failed to unmarshal token data: %w", err)
+	}
+
+	return authTokens, nil
+}
+
+// saveTokenToKeychain saves the refresh token to the system keychain
+func (a *Auth) saveTokenToKeychain(loginType config.LoginType, refreshToken string) error {
+	authTokens := AuthTokens{
+		Type:         loginType,
+		RefreshToken: refreshToken,
+	}
+
+	data, err := json.Marshal(authTokens)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tokens: %w", err)
+	}
+
+	return keyring.Set(APP_NAME, a.name, string(data))
+}
+
+// performSSOLogin performs SSO login and returns token, refresh token, and expiration
+func (a *Auth) performSSOLogin(ctx context.Context) (string, string, int64, error) {
+	httpClient, err := a.client.HttpClient()
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to get HTTP client: %w", err)
+	}
+
+	ctx = oidc.ClientContext(ctx, httpClient)
+
+	argoSettings, err := a.client.GetSettings()
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to get ArgoCD settings: %w", err)
+	}
+
+	oauth2conf, provider, err := a.client.OpenIDConfig(argoSettings)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to get OpenID config: %w", err)
+	}
+
+	token, refreshToken, err := a.oauth2Login(ctx, argoSettings.GetOIDCConfig(), oauth2conf, provider)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	var expires int64
+	if expiry := a.tryExtractExpiration(token); expiry > 0 {
+		expires = expiry
+	}
+
+	return token, refreshToken, expires, nil
+}
+
+// tryExtractExpiration attempts to extract expiration from a JWT token
+// Returns 0 if token is not a JWT or doesn't have expiration claim
+// This is a best-effort attempt and failures are not errors
+func (a *Auth) tryExtractExpiration(token string) int64 {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsedToken, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return 0
+	}
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return 0
+	}
+
+	if exp, ok := claims["exp"].(float64); ok {
+		return int64(exp)
+	}
+
+	return 0
+}

--- a/internal/auth/login-credentials.go
+++ b/internal/auth/login-credentials.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+)
+
+func (a *Auth) passwordLogin(ctx context.Context) (string, string, int64, error) {
+	return "", "", 0, fmt.Errorf("Not Implemented")
+}
+
+// refreshPasswordToken re-authenticates using stored credentials
+func (a *Auth) refreshPasswordToken(ctx context.Context, encodedCredentials string) (string, string, int64, error) {
+	return "", "", 0, fmt.Errorf("Not Implemented")
+}

--- a/internal/auth/login-credentials.go
+++ b/internal/auth/login-credentials.go
@@ -2,14 +2,128 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"strings"
+
+	loginscreen "github.com/Jack200062/ArguTUI/internal/ui/screens/login"
 )
 
 func (a *Auth) passwordLogin(ctx context.Context) (string, string, int64, error) {
-	return "", "", 0, fmt.Errorf("Not Implemented")
+	if a.app == nil || a.router == nil {
+		return "", "", 0, fmt.Errorf("app and router must be set for credential login")
+	}
+
+	a.logger.Debugf("Password login!")
+
+	var credentials loginscreen.Credentials
+	var loginError error
+	done := make(chan struct{})
+	cancelled := false
+
+	// Create login screen with callbacks
+	screen := loginscreen.NewLoginScreen(
+		a.app,
+		func(creds loginscreen.Credentials) {
+			credentials = creds
+			done <- struct{}{}
+		},
+		func() {
+			cancelled = true
+			close(done)
+		},
+	)
+
+	// Add screen to router
+	if err := a.router.AddScreen(screen); err != nil {
+		// Screen might already exist, try to switch to it
+		a.logger.Debugf("Screen already exists, switching to it: %v", err)
+	}
+
+	// Switch to login screen
+	if err := a.router.SwitchTo(loginscreen.LoginScreenName); err != nil {
+		return "", "", 0, fmt.Errorf("failed to show login screen: %w", err)
+	}
+
+	// Login loop - allow retries on failure
+	for {
+		select {
+		case <-done:
+			if cancelled {
+				return "", "", 0, fmt.Errorf("login cancelled by user")
+			}
+		case <-ctx.Done():
+			return "", "", 0, fmt.Errorf("login timed out: %w", ctx.Err())
+		}
+
+		creds := credentials
+		a.logger.Debugf("Creating Session with credentials %+v", creds)
+		// Attempt to create session with the provided credentials
+		createdSession, err := a.client.CreateSession(creds.Username, creds.Password)
+		if err != nil {
+			a.logger.Debugf("Login failed: %v", err)
+			loginError = err
+
+			// Show error on login screen and let user retry
+			a.app.QueueUpdateDraw(func() {
+				screen.ShowError("Login failed: Invalid username or password")
+			})
+			continue
+		}
+
+		// Success - clear any error message
+		a.app.QueueUpdateDraw(func() {
+			screen.ClearError()
+		})
+
+		// Try to extract expiration from the token (if it's a JWT)
+		expires := a.tryExtractExpiration(createdSession.Token)
+
+		// Encode credentials as "refresh token" for re-authentication
+		encodedCredentials := encodeCredentials(creds.Username, creds.Password)
+
+		return createdSession.Token, encodedCredentials, expires, nil
+	}
+
+	// This should never be reached, but satisfies the compiler
+	return "", "", 0, loginError
 }
 
 // refreshPasswordToken re-authenticates using stored credentials
 func (a *Auth) refreshPasswordToken(ctx context.Context, encodedCredentials string) (string, string, int64, error) {
-	return "", "", 0, fmt.Errorf("Not Implemented")
+	username, password, err := decodeCredentials(encodedCredentials)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to decode credentials: %w", err)
+	}
+
+	createdSession, err := a.client.CreateSession(username, password)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to create session: %w", err)
+	}
+
+	expires := a.tryExtractExpiration(createdSession.Token)
+
+	// Return same encoded credentials (they don't change)
+	return createdSession.Token, encodedCredentials, expires, nil
+}
+
+// encodeCredentials encodes username and password for storage
+func encodeCredentials(username, password string) string {
+	combined := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(combined))
+}
+
+// decodeCredentials decodes stored credentials
+func decodeCredentials(encoded string) (string, string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", "", err
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid credentials format")
+	}
+
+	return parts[0], parts[1], nil
 }

--- a/internal/auth/login-oauth.go
+++ b/internal/auth/login-oauth.go
@@ -1,0 +1,283 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"time"
+
+	"crypto/rand"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/settings"
+	argoOidc "github.com/argoproj/argo-cd/v2/util/oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+// For some reason it is REALLY IMPORTANT that redirect address is localhost:8085
+// otherwise we'll get "Unregistered redirect_uri" error from dex
+// @see https://github.com/argoproj/argo-cd/blob/c2e594c5/util/dex/config.go#L100
+const localServerPort = 8085
+
+const (
+	// stateNonceLength is the length of the random state parameter for CSRF protection
+	stateNonceLength = 24
+	// pkceVerifierLength is the length of PKCE code verifier (RFC 7636 recommends 43-128)
+	pkceVerifierLength = 43
+	// pkceCharset contains allowed characters for PKCE code verifier per RFC 7636
+	pkceCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+	// alphanumericCharset contains alphanumeric characters for general secure random strings
+	alphanumericCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	// oauthFlowTimeout is the maximum time allowed for completing the OAuth flow
+	oauthFlowTimeout = 5 * time.Minute
+	// serverShutdownTimeout is the time allowed for graceful server shutdown
+	serverShutdownTimeout = 2 * time.Second
+	// maxCallbackRequests prevents redirect loops in implicit flow
+	maxCallbackRequests = 2
+	// callbackPath is the OAuth callback endpoint path
+	callbackPath = "/auth/callback"
+)
+
+// generatePKCE creates a PKCE code verifier and challenge per RFC 7636
+func generatePKCE() (*pkceChallenge, error) {
+	verifier, err := SecureRandomString(pkceVerifierLength, pkceCharset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate PKCE verifier: %w", err)
+	}
+
+	challengeHash := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(challengeHash[:])
+
+	return &pkceChallenge{
+		Verifier:  verifier,
+		Challenge: challenge,
+	}, nil
+}
+
+// oauth2Login opens a browser, runs a temporary HTTP server to delegate OAuth2 login flow and
+// returns the JWT token and a refresh token (if supported)
+func (a *Auth) oauth2Login(
+	ctx context.Context,
+	oidcSettings *settings.OIDCConfig,
+	oauth2conf *oauth2.Config,
+	provider *oidc.Provider,
+) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, oauthFlowTimeout)
+	defer cancel()
+
+	// Setup listener. Setting port = 0 will allow to get random available port
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localServerPort))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create listener: %w", err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	oauth2conf.RedirectURL = fmt.Sprintf("http://localhost:%d%s", port, callbackPath)
+
+	stateNonce, err := SecureRandomString(stateNonceLength, alphanumericCharset)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate state nonce: %w", err)
+	}
+
+	pkce, err := generatePKCE()
+	if err != nil {
+		return "", "", err
+	}
+
+	grantType, err := inferGrantType(provider)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to infer grant type: %w", err)
+	}
+
+	authURL, err := buildAuthURL(oauth2conf, oidcSettings, grantType, stateNonce, pkce)
+	if err != nil {
+		return "", "", err
+	}
+
+	callbackSrv := newCallbackServer(a.logger, stateNonce, pkce.Verifier, oauth2conf, ctx)
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, callbackSrv.handleCallback)
+
+	server := &http.Server{
+		Handler: mux,
+	}
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		a.logger.Debugf("Starting callback server on port %d", port)
+		if err := server.Serve(listener); err != http.ErrServerClosed {
+			serverErrChan <- fmt.Errorf("callback server failed: %w", err)
+		}
+		close(serverErrChan)
+	}()
+
+	fmt.Printf("Opening browser for authentication\n")
+	fmt.Printf("Performing %s flow login: %s\n", grantType, authURL)
+
+	if err := a.browserOpener.Open(authURL); err != nil {
+		return "", "", fmt.Errorf("failed to open browser: %w", err)
+	}
+
+	// Wait for completion, timeout, or server error
+	select {
+	case <-callbackSrv.resultChan:
+		// Callback completed
+	case err := <-serverErrChan:
+		if err != nil {
+			return "", "", err
+		}
+	case <-ctx.Done():
+		return "", "", fmt.Errorf("oauth2 login timed out: %w", ctx.Err())
+	}
+
+	// Shutdown server gracefully
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+	defer shutdownCancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		a.logger.Debugf("Server shutdown error: %v", err)
+	}
+
+	// Get result
+	result := callbackSrv.getResult()
+	if result.Error != nil {
+		return "", "", fmt.Errorf("oauth2 callback failed: %w", result.Error)
+	}
+
+	fmt.Println("Authentication successful")
+	a.logger.Debugf("Token: %s", result.Token)
+	a.logger.Debugf("Refresh Token: %s", result.RefreshToken)
+
+	return result.Token, result.RefreshToken, nil
+}
+
+// refreshToken attempts to refresh an expired token using the refresh token
+// Returns: new token, new refresh token, expiration timestamp, error
+func (a *Auth) refreshOauthToken(ctx context.Context, refreshToken string) (string, string, int64, error) {
+	// Get ArgoCD settings for OAuth config
+	argoSettings, err := a.client.GetSettings()
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to get ArgoCD settings: %w", err)
+	}
+
+	oauth2conf, _, err := a.client.OpenIDConfig(argoSettings)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to get OpenID config: %w", err)
+	}
+
+	// Use the refresh token to get a new access token
+	tokenSource := oauth2conf.TokenSource(ctx, &oauth2.Token{
+		RefreshToken: refreshToken,
+	})
+
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	idToken, ok := newToken.Extra("id_token").(string)
+	if !ok {
+		return "", "", 0, fmt.Errorf("no id_token in refreshed token response")
+	}
+
+	newRefreshToken, _ := newToken.Extra("refresh_token").(string)
+	if newRefreshToken == "" {
+		newRefreshToken = refreshToken // Keep old refresh token if new one not provided
+	}
+
+	// Get expiration from the OAuth2 token
+	var expires int64
+	if !newToken.Expiry.IsZero() {
+		expires = newToken.Expiry.Unix()
+	}
+
+	return idToken, newRefreshToken, expires, nil
+}
+
+// buildAuthURL constructs the authorization URL based on grant type
+func buildAuthURL(
+	oauth2conf *oauth2.Config,
+	oidcSettings *settings.OIDCConfig,
+	grantType GrantType,
+	stateNonce string,
+	pkce *pkceChallenge,
+) (string, error) {
+	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+
+	if claims := oidcSettings.GetIDTokenClaims(); claims != nil {
+		opts = argoOidc.AppendClaimsAuthenticationRequestParameter(opts, claims)
+	}
+
+	switch grantType {
+	case GRANT_TYPE_AUTH_CODE:
+		opts = append(opts,
+			oauth2.SetAuthURLParam("code_challenge", pkce.Challenge),
+			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		)
+		return oauth2conf.AuthCodeURL(stateNonce, opts...), nil
+
+	case GRANT_TYPE_IMPLICIT:
+		return argoOidc.ImplicitFlowURL(oauth2conf, stateNonce, opts...)
+
+	default:
+		return "", fmt.Errorf("unsupported grant type: %v", grantType)
+	}
+}
+
+// GrantType represents OAuth2 grant types
+type GrantType string
+
+// See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+const (
+	// GRANT_TYPE_AUTH_CODE returns code that should be exchanged for access_token and refresh_token
+	GRANT_TYPE_AUTH_CODE GrantType = "authorization_code"
+	// GRANT_TYPE_IMPLICIT returns tokens directly
+	GRANT_TYPE_IMPLICIT GrantType = "implicit"
+)
+
+// inferGrantType determines the appropriate OAuth2 grant type from provider metadata
+func inferGrantType(provider *oidc.Provider) (GrantType, error) {
+	var claims struct {
+		ResponseTypesSupported []string `json:"response_types_supported"`
+	}
+
+	if err := provider.Claims(&claims); err != nil {
+		return "", fmt.Errorf("failed to get provider claims: %w", err)
+	}
+
+	for _, supportedType := range claims.ResponseTypesSupported {
+		if supportedType == "code" {
+			return GRANT_TYPE_AUTH_CODE, nil
+		}
+	}
+
+	return GRANT_TYPE_IMPLICIT, nil
+}
+
+// SecureRandomString generates a cryptographically-secure pseudo-random string
+// of length n using characters from the provided charset.
+func SecureRandomString(n int, charset string) (string, error) {
+	if n <= 0 {
+		return "", nil
+	}
+	if len(charset) == 0 {
+		return "", fmt.Errorf("charset cannot be empty")
+	}
+
+	result := make([]byte, n)
+	charsetLen := big.NewInt(int64(len(charset)))
+
+	for i := 0; i < n; i++ {
+		idx, err := rand.Int(rand.Reader, charsetLen)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random index: %w", err)
+		}
+		result[i] = charset[idx.Int64()]
+	}
+
+	return string(result), nil
+}

--- a/internal/auth/oauth-callback-server.go
+++ b/internal/auth/oauth-callback-server.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net/http"
+	"sync"
+
+	"github.com/Jack200062/ArguTUI/pkg/logging"
+	"golang.org/x/oauth2"
+)
+
+// implicitFlowRedirectScript redirects URL fragments to query parameters
+const implicitFlowRedirectScript = `<script>window.location.search = window.location.hash.substring(1)</script>`
+
+// successPageHTML is the HTML page shown after successful authentication
+const successPageHTML = `<!DOCTYPE html>
+<html>
+<head><title>Authentication Successful</title></head>
+<body style="background-color: #efefef;">
+	<div style="background-color: #fff;box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);min-height: 12em;display:flex;flex-direction: column;justify-content: center;align-items:center;box-sizing: border-box;max-width: 30em;margin: 2em auto;color: #333;font-family: 'Source Sans Pro', Helvetica, sans-serif;">
+		<div style="font-size:1.5em">Authentication successful!</div>
+        <p style="padding: 1em; font-size:1em; text-align:center">
+            Authentication was successful, you can now return to CLI. This page will close automatically.
+        </p>
+	</div>
+	<script>window.onload=function(){setTimeout(function(){window.close()}, 4000)}</script>
+</body>
+</html>`
+
+// callbackServer handles the OAuth2 callback
+type callbackServer struct {
+	logger       *logging.Logger
+	stateNonce   string
+	codeVerifier string
+	oauth2conf   *oauth2.Config
+	ctx          context.Context
+
+	mu           sync.Mutex
+	requestCount int
+	result       oauth2Result
+	resultChan   chan struct{}
+}
+
+func newCallbackServer(
+	logger *logging.Logger,
+	stateNonce string,
+	codeVerifier string,
+	oauth2conf *oauth2.Config,
+	ctx context.Context,
+) *callbackServer {
+	return &callbackServer{
+		logger:       logger,
+		stateNonce:   stateNonce,
+		codeVerifier: codeVerifier,
+		oauth2conf:   oauth2conf,
+		ctx:          ctx,
+		resultChan:   make(chan struct{}),
+	}
+}
+
+func (cs *callbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	cs.logger.Debugf("OAuth callback: %s", r.URL)
+
+	// Check for OAuth error response
+	if formErr := r.FormValue("error"); formErr != "" {
+		cs.completeWithError(w, fmt.Errorf("%s: %s", formErr, r.FormValue("error_description")))
+		return
+	}
+
+	// Increment and check request count to prevent redirect loops
+	cs.mu.Lock()
+	cs.requestCount++
+	count := cs.requestCount
+	cs.mu.Unlock()
+
+	if count > maxCallbackRequests {
+		cs.completeWithError(w, fmt.Errorf("unable to complete login flow: too many redirects"))
+		return
+	}
+
+	// Handle implicit flow redirect
+	if len(r.Form) == 0 {
+		fmt.Fprint(w, implicitFlowRedirectScript)
+		return
+	}
+
+	// Validate state to prevent CSRF
+	if state := r.FormValue("state"); state != cs.stateNonce {
+		cs.completeWithError(w, fmt.Errorf("invalid state parameter"))
+		return
+	}
+
+	// Try to get token from implicit flow first
+	if tokenString := r.FormValue("id_token"); tokenString != "" {
+		cs.completeWithSuccess(w, tokenString, "")
+		return
+	}
+
+	// Handle authorization code flow
+	code := r.FormValue("code")
+	if code == "" {
+		cs.completeWithError(w, fmt.Errorf("no code in request: %q", r.Form))
+		return
+	}
+
+	token, refreshToken, err := cs.exchangeCode(code)
+	if err != nil {
+		cs.completeWithError(w, err)
+		return
+	}
+
+	cs.completeWithSuccess(w, token, refreshToken)
+}
+
+func (cs *callbackServer) exchangeCode(code string) (string, string, error) {
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("code_verifier", cs.codeVerifier),
+	}
+
+	tok, err := cs.oauth2conf.Exchange(cs.ctx, code, opts...)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to exchange code: %w", err)
+	}
+
+	tokenString, ok := tok.Extra("id_token").(string)
+	if !ok {
+		return "", "", fmt.Errorf("no id_token in token response")
+	}
+
+	refreshToken, _ := tok.Extra("refresh_token").(string)
+	return tokenString, refreshToken, nil
+}
+
+func (cs *callbackServer) completeWithSuccess(w http.ResponseWriter, token, refreshToken string) {
+	cs.mu.Lock()
+	cs.result = oauth2Result{Token: token, RefreshToken: refreshToken}
+	cs.mu.Unlock()
+
+	fmt.Fprint(w, successPageHTML)
+	close(cs.resultChan)
+}
+
+func (cs *callbackServer) completeWithError(w http.ResponseWriter, err error) {
+	cs.mu.Lock()
+	cs.result = oauth2Result{Error: err}
+	cs.mu.Unlock()
+
+	http.Error(w, html.EscapeString(err.Error()), http.StatusBadRequest)
+	close(cs.resultChan)
+}
+
+func (cs *callbackServer) getResult() oauth2Result {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.result
+}

--- a/internal/transport/argocd/client.go
+++ b/internal/transport/argocd/client.go
@@ -3,12 +3,17 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/Jack200062/ArguTUI/config"
 	"github.com/Jack200062/ArguTUI/pkg/logging"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/settings"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
 )
 
 type ArgoCdClient struct {
@@ -16,6 +21,10 @@ type ArgoCdClient struct {
 	client apiclient.Client
 	logger *logging.Logger
 	ctx    context.Context
+}
+
+func (a *ArgoCdClient) HttpClient() (*http.Client, error) {
+	return a.client.HTTPClient()
 }
 
 func NewArgoCdClient(cfg *config.Instance, l *logging.Logger, ctx context.Context) *ArgoCdClient {
@@ -36,11 +45,14 @@ func NewArgoCdClient(cfg *config.Instance, l *logging.Logger, ctx context.Contex
 	}
 }
 
+// TODO: cache clients returned bu New...Client() calls to reuse GRPC connections
+
 func (a *ArgoCdClient) GetApps() ([]Application, error) {
-	_, appClient, err := a.client.NewApplicationClient()
+	closer, appClient, err := a.client.NewApplicationClient()
 	if err != nil {
 		return nil, a.logger.Errorf("Error creating argocd client: %v", err)
 	}
+	defer closer.Close()
 	appList, err := appClient.List(a.ctx, &application.ApplicationQuery{})
 	if err != nil {
 		return nil, a.logger.Errorf("Error getting application list: %v", err)
@@ -87,10 +99,11 @@ func (a *ArgoCdClient) GetApps() ([]Application, error) {
 }
 
 func (a *ArgoCdClient) GetAppResources(appName string) ([]Resource, error) {
-	_, appClient, err := a.client.NewApplicationClient()
+	closer, appClient, err := a.client.NewApplicationClient()
 	if err != nil {
 		return nil, a.logger.Errorf("Error creating argocd client: %v", err)
 	}
+	defer closer.Close()
 
 	tree, err := a.GetResourceTree(appName)
 	if err != nil {
@@ -141,10 +154,11 @@ func (a *ArgoCdClient) GetAppResources(appName string) ([]Resource, error) {
 }
 
 func (a *ArgoCdClient) GetResourceTree(appName string) (*v1alpha1.ApplicationTree, error) {
-	_, appClient, err := a.client.NewApplicationClient()
+	closer, appClient, err := a.client.NewApplicationClient()
 	if err != nil {
 		return nil, a.logger.Errorf("Error creating ArgoCD application client: %v", err)
 	}
+	defer closer.Close()
 	query := &application.ResourcesQuery{
 		ApplicationName: &appName,
 	}
@@ -156,11 +170,11 @@ func (a *ArgoCdClient) GetResourceTree(appName string) (*v1alpha1.ApplicationTre
 }
 
 func (a *ArgoCdClient) RefreshApp(appName string, refreshType string) error {
-	_, appClient, err := a.client.NewApplicationClient()
+	closer, appClient, err := a.client.NewApplicationClient()
 	if err != nil {
-		return a.logger.Errorf("Error getting application client: %v", err)
+		return a.logger.Errorf("Error getting application client: %+v", err)
 	}
-
+	defer closer.Close()
 	_, err = appClient.Get(a.ctx, &application.ApplicationQuery{
 		Name:    &appName,
 		Refresh: &refreshType,
@@ -173,10 +187,11 @@ func (a *ArgoCdClient) RefreshApp(appName string, refreshType string) error {
 }
 
 func (a *ArgoCdClient) SyncApp(appName string) error {
-	_, appClient, err := a.client.NewApplicationClient()
+	closer, appClient, err := a.client.NewApplicationClient()
 	if err != nil {
-		return a.logger.Errorf("Error getting application client: %v", err)
+		return a.logger.Errorf("Error getting application client: %+v", err)
 	}
+	defer closer.Close()
 	syncRequest := &application.ApplicationSyncRequest{
 		Name: &appName,
 	}
@@ -188,10 +203,11 @@ func (a *ArgoCdClient) SyncApp(appName string) error {
 }
 
 func (a *ArgoCdClient) DeleteApp(appName string) error {
-	_, appClient, err := a.client.NewApplicationClient()
+	closer, appClient, err := a.client.NewApplicationClient()
 	if err != nil {
-		return a.logger.Errorf("Error getting application client: %v", err)
+		return a.logger.Errorf("Error getting application client: %+v", err)
 	}
+	defer closer.Close()
 	deleteRequest := &application.ApplicationDeleteRequest{
 		Name: &appName,
 	}
@@ -200,4 +216,33 @@ func (a *ArgoCdClient) DeleteApp(appName string) error {
 		return a.logger.Errorf("Error deleting app %s: %v", appName, err)
 	}
 	return nil
+}
+
+// Prepare OAuth2 config and openId dsicovert provider
+func (a *ArgoCdClient) OpenIDConfig(conf *settings.Settings) (*oauth2.Config, *oidc.Provider, error) {
+	return a.client.OIDCConfig(a.ctx, conf)
+}
+
+// Get ArgoCD Settings via GET /api/v1/settings
+func (a *ArgoCdClient) GetSettings() (*settings.Settings, error) {
+	closer, settingsClient, err := a.client.NewSettingsClient()
+	if err != nil {
+		return nil, a.logger.Errorf("Error getting settings client: %+v", err)
+	}
+	defer closer.Close()
+
+	return settingsClient.Get(a.ctx, &settings.SettingsQuery{})
+}
+
+func (a *ArgoCdClient) CreateSession(username string, password string) (*session.SessionResponse, error) {
+	closer, sessionClient, err := a.client.NewSessionClient()
+	if err != nil {
+		return nil, a.logger.Errorf("Error getting session client: %+v", err)
+	}
+	defer closer.Close()
+	request := session.SessionCreateRequest{
+		Username: username,
+		Password: password,
+	}
+	return sessionClient.Create(a.ctx, &request)
 }

--- a/internal/ui/router.go
+++ b/internal/ui/router.go
@@ -74,7 +74,10 @@ func (r *Router) SwitchTo(name string) error {
 		r.history = append(r.history, r.current.Name())
 	}
 	r.current = screen
-	r.app.SetRoot(screen.Init(), true)
+	primitive := screen.Init()
+	r.app.QueueUpdateDraw(func() {
+		r.app.SetRoot(primitive, true)
+	})
 	return nil
 }
 
@@ -99,7 +102,10 @@ func (r *Router) Back() error {
 	}
 
 	r.current = screen
-	r.app.SetRoot(screen.Init(), true)
+	primitive := screen.Init()
+	r.app.QueueUpdateDraw(func() {
+		r.app.SetRoot(primitive, true)
+	})
 	return nil
 }
 
@@ -123,7 +129,10 @@ func (r *Router) CloseModal() {
 		return
 	}
 	r.isModal = false
-	r.app.SetRoot(r.current.Init(), true)
+	primitive := r.current.Init()
+	r.app.QueueUpdateDraw(func() {
+		r.app.SetRoot(primitive, true)
+	})
 }
 
 func (r *Router) IsModalActive() bool {

--- a/internal/ui/screens/login/screen.go
+++ b/internal/ui/screens/login/screen.go
@@ -1,0 +1,186 @@
+package loginscreen
+
+import (
+	"sync"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	LoginScreenName = "login"
+)
+
+// Credentials holds the username and password
+type Credentials struct {
+	Username string
+	Password string
+}
+
+// LoginScreen provides a form for username/password login
+type LoginScreen struct {
+	app      *tview.Application
+	form     *tview.Form
+	flex     *tview.Flex
+	errorBox *tview.TextView
+	onSubmit func(Credentials)
+	onCancel func()
+
+	mu          sync.Mutex
+	credentials Credentials
+	submitted   bool
+}
+
+// NewLoginScreen creates a new login screen
+func NewLoginScreen(
+	app *tview.Application,
+	onSubmit func(Credentials),
+	onCancel func(),
+) *LoginScreen {
+	return &LoginScreen{
+		app:      app,
+		onSubmit: onSubmit,
+		onCancel: onCancel,
+	}
+}
+
+func (s *LoginScreen) Name() string {
+	return LoginScreenName
+}
+
+func (s *LoginScreen) Init() tview.Primitive {
+	// Color scheme
+	textColor := tcell.NewHexColor(0x00bebe)
+	mainTextColor := tcell.NewHexColor(0x805700)
+	backgroundColor := tcell.NewHexColor(0x000000)
+	borderColor := tcell.NewHexColor(0x63a0bf)
+	fieldBgColor := tcell.NewHexColor(0x1a1a1a)
+	buttonBgColor := tcell.NewHexColor(0x017be9)
+	buttonTextColor := tcell.NewHexColor(0xffffff)
+	errorColor := tcell.NewHexColor(0xff5555)
+
+	// Create error message box (hidden by default)
+	s.errorBox = tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetTextColor(errorColor)
+	s.errorBox.SetBackgroundColor(backgroundColor)
+
+	// Create form
+	s.form = tview.NewForm().
+		SetFieldBackgroundColor(fieldBgColor).
+		SetFieldTextColor(mainTextColor).
+		SetLabelColor(textColor).
+		SetButtonBackgroundColor(buttonBgColor).
+		SetButtonTextColor(buttonTextColor)
+
+	s.form.
+		SetBackgroundColor(backgroundColor).
+		SetBorderColor(borderColor).
+		SetBorder(true).
+		SetTitle(" Login to ArgoCD ").
+		SetTitleAlign(tview.AlignCenter).
+		SetTitleColor(textColor)
+
+	// Add form fields
+	s.form.AddInputField("Username", "", 30, nil, func(text string) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.credentials.Username = text
+	})
+
+	s.form.AddPasswordField("Password", "", 30, '*', func(text string) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.credentials.Password = text
+	})
+
+	// Add buttons
+	s.form.AddButton("Login", func() {
+		s.mu.Lock()
+		creds := s.credentials
+		s.submitted = true
+		s.mu.Unlock()
+
+		if s.onSubmit != nil {
+			s.onSubmit(creds)
+		}
+	})
+
+	s.form.AddButton("Cancel", func() {
+		if s.onCancel != nil {
+			s.onCancel()
+		}
+	})
+
+	// Set button colors
+	s.form.SetButtonsAlign(tview.AlignCenter)
+
+	// Handle keyboard shortcuts
+	s.form.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyEscape:
+			if s.onCancel != nil {
+				s.onCancel()
+			}
+			return nil
+		case tcell.KeyCtrlC:
+			s.app.Stop()
+			return nil
+		}
+		return event
+	})
+
+	// Create a container for form and error message
+	formContainer := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(s.form, 0, 1, true).
+		AddItem(s.errorBox, 2, 0, false)
+
+	// Create flex container to center the form
+	s.flex = tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(
+			tview.NewFlex().
+				SetDirection(tview.FlexColumn).
+				AddItem(nil, 0, 1, false).
+				AddItem(formContainer, 50, 1, true).
+				AddItem(nil, 0, 1, false),
+			14, 1, true,
+		).
+		AddItem(nil, 0, 1, false)
+
+	s.flex.SetBackgroundColor(backgroundColor)
+
+	return s.flex
+}
+
+// GetCredentials returns the submitted credentials
+func (s *LoginScreen) GetCredentials() (Credentials, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.credentials, s.submitted
+}
+
+// ShowError displays an error message on the login screen
+func (s *LoginScreen) ShowError(message string) {
+	if s.errorBox != nil {
+		s.errorBox.SetText(message)
+	}
+}
+
+// ClearError clears the error message
+func (s *LoginScreen) ClearError() {
+	if s.errorBox != nil {
+		s.errorBox.SetText("")
+	}
+}
+
+// Reset clears the form data
+func (s *LoginScreen) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.credentials = Credentials{}
+	s.submitted = false
+}


### PR DESCRIPTION
This PR adds option to login via SSO or credentials in addition to API Token. This allows working with ArgoCD instances where user does not have permissions to create API token.

The main logic of OAuth login is implemented as it is done in [argocd client](https://github.com/argoproj/argo-cd/blob/master/cmd/argocd/commands/login.go). The main motivation to re-implement it was to be able to switch from argocd dependency to lightweight HTTP client in the future.

The user/password auth is implemented by exchaning credentials to token via [sessions api](https://cd.apps.argoproj.io/swagger-ui#tag/SessionService/operation/SessionService_Create). The login screen code is heavily LLM-assissted so it is far from the best implementation

The auth service also stores credentials and refresh_token into keyring, to avoid prompting user on each run. 